### PR TITLE
DRYD-54: Tweak RecordHeader styles.

### DIFF
--- a/styles/cspace-ui/RecordHeader.css
+++ b/styles/cspace-ui/RecordHeader.css
@@ -1,15 +1,10 @@
 .common {
   flex: 1;
   margin: 0;
-  padding: 0 10px 0 0;
   background: white;
   width: 100%;
   box-sizing: border-box;
 }
-
-.common > header {
-  min-height: 60px;
-} 
 
 .common > header > div {
   display: flex;
@@ -18,40 +13,12 @@
 }
 
 .docked {
+  composes: common;
   position: fixed;
-  width: 68%;
+  width: calc(calc(100% - 7px) * .7);
   left: 0;
-  top: 70;
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.3);
+  top: 65;
+  box-shadow: 0 3px 12px -6px rgba(0, 0, 0, 0.3);
   z-index: 99;
-  background-color: #fff;
-  padding: 8px;
-}
-
-.docked > :global(.cspace-ui-RecordHistory--common) {
-  padding-right: 14px;
-}
-
-@media (min-width: 1100px) {
-  .docked {
-    width: 68.25%;
-  }
-}
-
-@media (min-width: 1300px) {
-  .docked {
-    width: 68.5%;
-  }
-}
-
-@media (min-width: 1600px) {
-  .docked {
-    width: 68.75%;
-  }
-}
-
-@media (min-width: 1900px) {
-  .docked {
-    width: 69%;
-  }
+  padding: 10px;
 }


### PR DESCRIPTION
This removes the need for media queries, and adjusts the docked record header to how I'd like it to look.